### PR TITLE
Wrap the request payload exceptions around Zend Log WARN

### DIFF
--- a/src/app/code/community/EbayEnterprise/Eb2cFraud/Model/Build/Request.php
+++ b/src/app/code/community/EbayEnterprise/Eb2cFraud/Model/Build/Request.php
@@ -416,6 +416,7 @@ class EbayEnterprise_Eb2cFraud_Model_Build_Request
  
 	$orderBillingAddress = $this->_order->getBillingAddress();
         $orderPayment = $this->_order->getPayment();
+
         if ($orderBillingAddress && $orderPayment) {
             $this->_buildPayment($subPayloadTotalCost->getFormOfPayment(), $orderBillingAddress, $orderPayment);
         }

--- a/src/app/code/community/EbayEnterprise/Eb2cFraud/Model/Risk/Order.php
+++ b/src/app/code/community/EbayEnterprise/Eb2cFraud/Model/Risk/Order.php
@@ -192,12 +192,18 @@ class EbayEnterprise_Eb2cFraud_Model_Risk_Order
 	{
         $request = $this->_getNewEmptyRequest();
 
-        $payload = Mage::getModel('ebayenterprise_eb2cfraud/build_request', array(
-            'request' => $request,
-            'order' => $order,
-        ))->build();
+	try
+	{
+        	$payload = Mage::getModel('ebayenterprise_eb2cfraud/build_request', array(
+        	    'request' => $request,
+        	    'order' => $order,
+        	))->build();
 
-	$this->_payloadXml = $payload->serialize();
+		$this->_payloadXml = $payload->serialize();
+	} catch( Exception $e ) {
+                $logMessage = sprintf('[%s] Error Payload RiskAssessmentRequest Body: %s', __CLASS__, print_r($payload, true));
+                Mage::log($logMessage, Zend_Log::WARN);
+        }
 
 	$apiConfig = $this->_setupApiConfig($payload, $this->_getNewEmptyResponse());
         $response = $this->_sendRequest($this->_getApi($apiConfig), $order);
@@ -214,12 +220,18 @@ class EbayEnterprise_Eb2cFraud_Model_Risk_Order
 
                 $request = $this->_getNewOCREmptyRequest();
 
-                $payload = Mage::getModel('ebayenterprise_eb2cfraud/build_OCRequest', array(
-                	'request' => $request,
-                        'order' => $order,
-                ))->build();
-
-		$this->_payloadXml = $payload->serialize();
+		try
+		{
+                	$payload = Mage::getModel('ebayenterprise_eb2cfraud/build_OCRequest', array(
+                		'request' => $request,
+                	        'order' => $order,
+                	))->build();
+			$this->_payloadXml = $payload->serialize();
+		} catch( Exception $e ) {
+			$logMessage = sprintf('[%s] Error Payload OrderConfirmationRequest Body: %s', __CLASS__, print_r($payload, true));
+                        Mage::log($logMessage, Zend_Log::WARN);
+		}	
+	
         	$apiConfig = $this->_setupApiConfig($payload, $this->_getNewEmptyResponse());
         	$response = $this->_sendRequest($this->_getApi($apiConfig), $orderNull);
         }

--- a/src/app/code/community/EbayEnterprise/Eb2cFraud/etc/config.xml
+++ b/src/app/code/community/EbayEnterprise/Eb2cFraud/etc/config.xml
@@ -86,7 +86,7 @@ http://opensource.org/licenses/osl-3.0.php
             </ebayenterprise_eb2cfraud>
         </blocks>
         <events>
-		<checkout_submit_all_after>
+		<sales_order_place_after>
 			<observers>
 				<handle_multi_shipping_orders_risk_fraud>
 					<class>ebayenterprise_eb2cfraud/observer</class>
@@ -94,7 +94,7 @@ http://opensource.org/licenses/osl-3.0.php
 					<type>singleton</type>
 				</handle_multi_shipping_orders_risk_fraud>
 			</observers>
-		</checkout_submit_all_after>
+		</sales_order_place_after>
 		<sales_quote_remove_item>
                 	<observers>
                 	    <ebayenterprise_eb2cfraud_add_cartcount>


### PR DESCRIPTION
Wrap the request payload exceptions around Zend Log WARN.

Change event listener to use place order after to match payments flow. 
